### PR TITLE
support hack-http-request-response-interfaces v0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,11 @@
   ],
   "require": {
     "hhvm": "^4.0",
-    "facebook/hack-http-request-response-interfaces": "^0.2"
+    "facebook/hack-http-request-response-interfaces": "^0.2|^0.3"
   },
   "autoload": {
     "psr-4": {
       "Usox\\HackHttpFactory\\": "src/"
-    }
-  },
-  "config": {
-    "platform": {
-      "hhvm": "4.0.0"
     }
   }
 }


### PR DESCRIPTION
hack-http-request-response-interfaces has a new release: https://github.com/hhvm/hack-http-request-response-interfaces/releases

The v0.3 release doesn't change anything about the interfaces, so we can support it without any changes here.